### PR TITLE
fix: limit OAR079 scope to standard http methods

### DIFF
--- a/apq-spectral.json
+++ b/apq-spectral.json
@@ -1144,7 +1144,7 @@
       "description": "Operations with path parameters should include a 404 Not Found response.",
       "message": "OAR079: Path parameter present, but missing 404 Not Found response.",
       "severity": "warn",
-      "given": "$.paths[*][*]",
+      "given": "$.paths[*][get,post,put,patch,delete]",
       "then": {
         "field": "responses.404",
         "function": "truthy"

--- a/apq-spectral.yaml
+++ b/apq-spectral.yaml
@@ -822,7 +822,7 @@ rules:
     description: "Operations with path parameters should include a 404 Not Found response."
     message: "OAR079: Path parameter present, but missing 404 Not Found response."
     severity: "warn"
-    given: "$.paths[*][*]"
+    given: "$.paths[*][get,post,put,patch,delete]"
     then:
       field: responses.404
       function: truthy


### PR DESCRIPTION
Restrict OAR079 rule to valid HTTP methods to avoid false positives on x-attributes

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Issue Number: #93 