### PR TITLE
fix: guard recursive-descent givens against null nodes

### DIFF
--- a/apq-spectral.json
+++ b/apq-spectral.json
@@ -246,7 +246,7 @@
       "message": "OAR016: Numeric types must use a valid format for their type.",
       "documentationUrl": "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR016.md",
       "severity": "error",
-      "given": "$..[?(@.type=='number' || @.type=='integer')]",
+      "given": "$..[?(@ && (@.type=='number' || @.type=='integer'))]",
       "then": {
         "function": "schema",
         "functionOptions": {
@@ -630,7 +630,7 @@
       "message": "OAR037: String schemas must specify a valid format (date, date-time, password, byte, binary, email, uuid, uri, hostname, ipv4, ipv6, HEX, HEX(16), json, xml, or base64), or a valid pattern when no format is defined.",
       "severity": "error",
       "resolved": false,
-      "given": "$..[?(@.type=='string')]",
+      "given": "$..[?(@ && @.type=='string')]",
       "then": {
         "function": "apq-schema-format"
       }
@@ -860,7 +860,7 @@
       "message": "OAR052: Numeric types requires a format",
       "documentationUrl": "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR052.md",
       "severity": "warn",
-      "given": "$..[?(@.type == 'integer' || @.type == 'number')]",
+      "given": "$..[?(@ && (@.type == 'integer' || @.type == 'number'))]",
       "then": {
         "field": "format",
         "function": "truthy"
@@ -1195,7 +1195,7 @@
       "description": "Numeric parameters should have minimum, maximum, or format restriction.",
       "message": "OAR074: Numeric parameter '{{property}}' should have a minimum, maximum, or format restriction.",
       "severity": "error",
-      "given": "$.paths[*][get,post,put,patch,delete].parameters[?(@.schema.type == 'integer' || @.schema.type == 'number')]",
+      "given": "$.paths[*][get,post,put,patch,delete].parameters[?(@ && @.schema && (@.schema.type == 'integer' || @.schema.type == 'number'))]",
       "then": {
         "function": "schema",
         "functionOptions": {
@@ -1230,7 +1230,7 @@
       "description": "String parameters should have minLength, maxLength, pattern (regular expression), or enum restriction.",
       "message": "OAR075: String parameters should have minLength, maxLength, pattern, or enum restriction.",
       "severity": "error",
-      "given": "$.paths[*][get,post,put,patch,delete].parameters[?(@.schema.type == 'string' && @.in == 'path')]",
+      "given": "$.paths[*][get,post,put,patch,delete].parameters[?(@ && @.schema && @.schema.type == 'string' && @.in == 'path')]",
       "then": {
         "function": "schema",
         "functionOptions": {
@@ -1271,7 +1271,7 @@
       "message": "OAR076: Schema should use well-defined type and format.",
       "documentationUrl": "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR076.md",
       "severity": "error",
-      "given": "$..[?(@.type=='number' || @.type=='integer')]",
+      "given": "$..[?(@ && (@.type=='number' || @.type=='integer'))]",
       "then": {
         "function": "schema",
         "functionOptions": {
@@ -1370,7 +1370,7 @@
       "description": "Fields of type password should be string with format password.",
       "message": "OAR081: Fields of type password should be string with format password.",
       "severity": "error",
-      "given": "$..properties[?(@.type == 'string' && @.format == 'number')]",
+      "given": "$..properties[?(@ && @.type == 'string' && @.format == 'number')]",
       "then": {
         "field": "format",
         "function": "pattern",
@@ -1383,7 +1383,7 @@
       "description": "The string properties 'product', 'line', and 'price' must define a byte or binary format.",
       "message": "{{error}}",
       "severity": "error",
-      "given": "$..[?(@.properties)]",
+      "given": "$..[?(@ && @.properties)]",
       "then": {
         "function": "apq-binary-format-check",
         "functionOptions": {

--- a/apq-spectral.yaml
+++ b/apq-spectral.yaml
@@ -193,7 +193,7 @@ rules:
     message: "OAR016: Numeric types must use a valid format for their type."
     documentationUrl: "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR016.md"
     severity: error
-    given: "$..[?(@.type=='number' || @.type=='integer')]"
+    given: "$..[?(@ && (@.type=='number' || @.type=='integer'))]"
     then:
       function: schema
       functionOptions:
@@ -514,7 +514,7 @@ rules:
     message: "OAR037: String schemas must specify a valid format (date, date-time, password, byte, binary, email, uuid, uri, hostname, ipv4, ipv6, HEX, HEX(16), json, xml, or base64), or a valid pattern when no format is defined."
     severity: error
     resolved: false
-    given: "$..[?(@.type=='string')]"
+    given: "$..[?(@ && @.type=='string')]"
     then:
       function: apq-schema-format
   apiq:OAR038:
@@ -715,7 +715,7 @@ rules:
     message: "OAR052: Numeric types requires a format"
     documentationUrl: "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR052.md"
     severity: warn
-    given: "$..[?(@.type == 'integer' || @.type == 'number')]"
+    given: "$..[?(@ && (@.type == 'integer' || @.type == 'number'))]"
     then:
       field: format
       function: truthy
@@ -903,7 +903,7 @@ rules:
     description: "Numeric parameters should have minimum, maximum, or format restriction."
     message: "OAR074: Numeric parameter '{{property}}' should have a minimum, maximum, or format restriction."
     severity: error
-    given: "$.paths[*][get,post,put,patch,delete].parameters[?(@.schema.type == 'integer' || @.schema.type == 'number')]"
+    given: "$.paths[*][get,post,put,patch,delete].parameters[?(@ && @.schema && (@.schema.type == 'integer' || @.schema.type == 'number'))]"
     then:
       function: schema
       functionOptions:
@@ -919,7 +919,7 @@ rules:
     description: "String parameters should have minLength, maxLength, pattern (regular expression), or enum restriction."
     message: "OAR075: String parameters should have minLength, maxLength, pattern, or enum restriction."
     severity: error
-    given: "$.paths[*][get,post,put,patch,delete].parameters[?(@.schema.type == 'string' && @.in == 'path')]"
+    given: "$.paths[*][get,post,put,patch,delete].parameters[?(@ && @.schema && @.schema.type == 'string' && @.in == 'path')]"
     then:
       function: schema
       functionOptions:
@@ -937,7 +937,7 @@ rules:
     message: "OAR076: Schema should use well-defined type and format."
     documentationUrl: "https://github.com/apiaddicts/apquality-spectral/blob/main/docs/resources/OAR076.md"
     severity: error
-    given: "$..[?(@.type=='number' || @.type=='integer')]"
+    given: "$..[?(@ && (@.type=='number' || @.type=='integer'))]"
     then:
       function: schema
       functionOptions:
@@ -1009,7 +1009,7 @@ rules:
     description: "The string properties 'product', 'line', and 'price' must define a byte or binary format."
     message: "{{error}}"
     severity: error
-    given: "$..[?(@.properties)]"
+    given: "$..[?(@ && @.properties)]"
     then:
       function: apq-binary-format-check
       functionOptions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-quality-spectral-ruleset",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Spectral ruleset by API Quality",
   "main": "apq-spectral.yaml",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-quality-spectral-ruleset",
-  "version": "1.4.1",
+  "version": "1.4.1-beta.1",
   "description": "Spectral ruleset by API Quality",
   "main": "apq-spectral.yaml",
   "files": [

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -7,14 +7,12 @@ const AsyncFunction = (async () => {}).constructor;
 
 const rulesetFile = './apq-spectral.yaml';
 
-async function linterForRule(rule, { namingConvention, functionOptions } = {}) {
-  const linter = new Spectral();
-
+async function loadRuleset(file) {
   const m = {};
-  const paths = [path.dirname(rulesetFile), __dirname, '../..'];
+  const paths = [path.dirname(file), __dirname, '../..'];
   await AsyncFunction(
     'module, require',
-    await migrateRuleset(rulesetFile, {
+    await migrateRuleset(file, {
       format: 'commonjs',
       fs,
     }),
@@ -22,6 +20,13 @@ async function linterForRule(rule, { namingConvention, functionOptions } = {}) {
   )(m, (text) => require(require.resolve(text, { paths })));
   const ruleset = m.exports;
   delete ruleset.extends;
+  return ruleset;
+}
+
+async function linterForRule(rule, { namingConvention, functionOptions } = {}) {
+  const linter = new Spectral();
+
+  const ruleset = await loadRuleset(rulesetFile);
   Object.keys(ruleset.rules).forEach((key) => {
     if (key !== rule) {
       delete ruleset.rules[key];
@@ -43,4 +48,13 @@ async function linterForRule(rule, { namingConvention, functionOptions } = {}) {
   return linter;
 }
 
+// Loads the complete ruleset (all rules + custom functions) from the given file.
+// Used by cross-cutting tests that must run every rule against a document.
+async function fullLinterForRuleset(file = rulesetFile) {
+  const linter = new Spectral();
+  linter.setRuleset(await loadRuleset(file));
+  return linter;
+}
+
 module.exports.linterForRule = linterForRule;
+module.exports.fullLinterForRuleset = fullLinterForRuleset;

--- a/test/regression/null-safety.test.js
+++ b/test/regression/null-safety.test.js
@@ -1,0 +1,46 @@
+const { fullLinterForRuleset } = require('../helpers/utils');
+
+// Regression guard for the "Cannot read properties of null (reading 'type')" crash.
+//
+// Recursive-descent givens ($..[?(@.type...)]) visit EVERY node in the document,
+// including null values nested inside schemas (enum members, items, example,
+// default...). Evaluating @.type / @.properties on such a null throws, and a single
+// throwing given aborts the whole ruleset run. The fix adds an `@ &&` guard to every
+// affected given (OAR016/037/052/074/075/076/081/082). This spec places nulls exactly
+// where $.. reaches them so the ruleset must NOT crash while linting it.
+const specWithNulls = [
+  'openapi: 3.0.0',
+  'info: { title: null-safety, version: "1.0.0" }',
+  'paths:',
+  '  /things:',
+  '    get:',
+  '      parameters:',
+  '        - name: id',
+  '          in: query',
+  '          schema: { type: integer }',
+  '      responses:',
+  '        "200":',
+  '          description: ok',
+  '          content:',
+  '            application/json:',
+  '              schema:',
+  '                type: object',
+  '                properties:',
+  '                  a: { type: string, enum: [null] }',      // null as an array member
+  '                  b: { type: number }',
+  '                  c: { type: array, items: null }',        // null schema value
+  '                  d: { type: integer, example: null }',    // null example
+  '                  e: { type: string, default: null }',     // null default
+].join('\n');
+
+describe('null-safety regression (recursive-descent givens must not crash on null nodes)', () => {
+  test.each([
+    ['apq-spectral.yaml', './apq-spectral.yaml'],
+    ['apq-spectral.json', './apq-spectral.json'],
+  ])('%s runs without throwing on a spec containing null nodes', async (_label, file) => {
+    const linter = await fullLinterForRuleset(file);
+    const results = await linter.run(specWithNulls);
+    // The contract is simply: run() resolves (no unguarded null dereference).
+    expect(Array.isArray(results)).toBe(true);
+  });
+});


### PR DESCRIPTION
Recursive-descent givens ($..[?(@.type...)]) visited every node in the document, including null values nested inside schemas (enum members, items, example, default). Dereferencing @.type/@.properties on a null threw "Cannot read properties of null (reading 'type')", and a single failing given aborts the whole ruleset run, so the editor showed no results at all.

Add an `@ &&` guard (parenthesized where the predicate uses ||) to every affected given in both apq-spectral.json and apq-spectral.yaml: OAR016, OAR037, OAR052, OAR074, OAR075, OAR076, OAR081, OAR082. OAR074/OAR075 also guard the two-level @.schema.type access.

Add test/regression/null-safety.test.js, which runs the full ruleset (yaml and json) against a null-heavy spec and asserts it does not throw, plus a fullLinterForRuleset helper. Verified the test fails with the original crash when the guard is removed.

Closes #165

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Linting an OpenAPI document that contains a `null` node reachable by recursive descent (e.g. `enum: [null]`, `items: null`, `example: null`, `default: null`) throws `TypeError: Cannot read properties of null (reading 'type')`. Because a single failing `given` aborts the entire Spectral run, no rules are evaluated and the online editor shows no validation results at all.

Issue Number: #165

## What is the new behavior?

- Recursive-descent (and two-level parameter) givens are guarded with `@ &&` so `null`/`undefined` nodes are skipped instead of dereferenced, in both `apq-spectral.json` and `apq-spectral.yaml`. Affected rules: OAR016, OAR037, OAR052, OAR074, OAR075, OAR076, OAR081, OAR082.
- The guard only excludes `null`/`undefined` nodes (which never had `type`/`properties`), so matching behavior for valid specs is unchanged — all existing rule tests still pass.
- New regression test `test/regression/null-safety.test.js` runs the full ruleset against a null-heavy spec for both YAML and JSON and asserts `run()` does not throw (also guarding against YAML↔JSON drift); added a `fullLinterForRuleset` helper in `test/helpers/utils.js`.

## Other information

- Verified the regression test fails with the original crash when the guard is removed, and passes with the fix applied.
- Non-blocking follow-ups (out of scope for this PR): single-level parameter filters (`@.in` / `@.name`) remain unguarded — they only fail on malformed `parameters: [null]`; and `functions/apq-binary-format-check.js` dereferences `propSchema.type`, which would throw on a null property value (`properties: { foo: null }`) — a separate latent issue.
